### PR TITLE
Fix flaws in generating signatures - Closes #7

### DIFF
--- a/SlaveWAMPServer.js
+++ b/SlaveWAMPServer.js
@@ -38,7 +38,7 @@ class SlaveWAMPServer extends WAMPServer {
 			else if (schemas.isValid(response, schemas.InterProcessRPCResponseSchema)) {
 				const callback = this.getCall(response);
 				if (callback) {
-					callback(response.err, response.data);
+					callback(response.error, response.data);
 					this.deleteCall(response);
 				}
 			}
@@ -67,7 +67,6 @@ class SlaveWAMPServer extends WAMPServer {
 		this.worker.sendToMaster(req);
 
 		this.saveCall(req, cb);
-
 	}
 
 	processWAMPRequest(request, socket) {

--- a/WAMPClient.js
+++ b/WAMPClient.js
@@ -13,7 +13,17 @@ class WAMPClient {
 	}
 
 	static generateSignature(procedureCalls) {
-		return `${(new Date()).getTime()}_${(Object.keys(procedureCalls).length - 1) + 1}`;
+		const generateNonce = () => Math.random() * 100000 | 0;
+
+		const tryGenerateSignature = (nonce) => {
+			const signatureCandidate = `${(new Date()).getTime()}_${nonce}`;
+			if (!procedureCalls[signatureCandidate]) {
+				return signatureCandidate;
+			}
+			return tryGenerateSignature(generateNonce());
+		};
+
+		return tryGenerateSignature(generateNonce());
 	}
 
 

--- a/WAMPServer.js
+++ b/WAMPServer.js
@@ -51,7 +51,6 @@ class WAMPServer {
 	 */
 	processWAMPRequest(request, socket) {
 		if (this.endpoints.rpc[request.procedure] && typeof this.endpoints.rpc[request.procedure] === 'function') {
-
 			return this.endpoints.rpc[request.procedure](request.data, this.reply.bind(this, socket, request));
 		}
 		else if (this.endpoints.event[request.procedure] && typeof this.endpoints.event[request.procedure] === 'function') {


### PR DESCRIPTION
The previous way of generating signatures had flaws - when multiple requests were sent in the exact same second as the response from any of previous had arrived, signatures of next requests were duplicated with at least of existing requests.

Closes #7