### PR TITLE
Missing unit tests for SlaveWAMPSocketServer - Closes #2

### DIFF
--- a/MasterWAMPServer.js
+++ b/MasterWAMPServer.js
@@ -29,8 +29,13 @@ class MasterWAMPServer extends WAMPServer {
 			}
 		});
 
-		socketCluster.on('workerExit', workerInfo =>
-			this.workerIndices.splice(this.workerIndices.indexOf(workerInfo.id)), 1);
+		socketCluster.on('workerExit', (workerInfo) => {
+			const existingWorkerIndex = this.workerIndices.indexOf(workerInfo.id);
+			if (existingWorkerIndex === -1) {
+				return;
+			}
+			this.workerIndices.splice(existingWorkerIndex, 1);
+		});
 	}
 
 	/**

--- a/MasterWAMPServer.js
+++ b/MasterWAMPServer.js
@@ -38,6 +38,7 @@ class MasterWAMPServer extends WAMPServer {
 	 * @param {WAMPRequestSchema} request
 	 * @param {*} error
 	 * @param {*} data
+	 * @returns {undefined}
 	 */
 	reply(socket, request, error, data) {
 		const payload = MasterWAMPServer.createResponsePayload(request, error, data);

--- a/MasterWAMPServer.spec.js
+++ b/MasterWAMPServer.spec.js
@@ -105,7 +105,7 @@ describe('MasterWAMPServer', () => {
 				beforeEach(() => {
 					onWorkerStartHandler = fakeSCServer.on.getCalls()[0].args[1];
 					validWorker = { id: validWorkerId };
-					sinon.stub(masterWAMPServer, 'reply');
+					masterWAMPServer.reply = sinon.stub(masterWAMPServer, 'reply');
 				});
 
 				after(() => {
@@ -135,7 +135,7 @@ describe('MasterWAMPServer', () => {
 				beforeEach(() => {
 					onWorkerExitHandler = fakeSCServer.on.getCalls()[2].args[1];
 					validWorker = { id: validWorkerId };
-					sinon.stub(masterWAMPServer, 'reply');
+					masterWAMPServer.reply = sinon.stub(masterWAMPServer, 'reply');
 				});
 
 				after(() => {

--- a/MasterWAMPServer.spec.js
+++ b/MasterWAMPServer.spec.js
@@ -6,18 +6,20 @@ const MasterWAMPServer = require('./MasterWAMPServer');
 const MasterWAMPRequestSchema = require('./schemas').MasterWAMPRequestSchema;
 
 describe('MasterWAMPServer', () => {
+	let fakeSCServer;
+	let masterWAMPServer;
+	const validWorkerId = 0;
+
+	beforeEach(() => {
+		fakeSCServer = {
+			on: sinon.spy(),
+			sendToWorker: sinon.spy(),
+		};
+		masterWAMPServer = new MasterWAMPServer(fakeSCServer);
+	});
+
 	describe('constructor', () => {
-		let fakeSCServer;
-
-		beforeEach(() => {
-			fakeSCServer = {
-				on: sinon.spy(),
-				sendToWorker: sinon.spy(),
-			};
-		});
-
 		it('create SlaveWAMPServer with socketCluster field', () => {
-			const masterWAMPServer = new MasterWAMPServer(fakeSCServer);
 			expect(masterWAMPServer).to.have.property('socketCluster').to.be.a('object');
 		});
 
@@ -36,9 +38,7 @@ describe('MasterWAMPServer', () => {
 			expect(fakeSCServer.on.getCalls()[1].args[1]).to.be.a('function');
 		});
 
-		describe('socketCluster.on("workerMessage")', () => {
-			let masterWAMPServer;
-
+		describe('socketCluster.on', () => {
 			const validMasterWAMPRequest = {
 				workerId: 0,
 				socketId: 'AYX',
@@ -59,50 +59,157 @@ describe('MasterWAMPServer', () => {
 
 
 			beforeEach(() => {
-				fakeSCServer = {
-					on: sinon.spy(),
-					sendToWorker: sinon.spy(),
-				};
-				masterWAMPServer = new MasterWAMPServer(fakeSCServer);
 				masterWAMPServer.processWAMPRequest = sinon.spy();
 			});
 
-			it('should call processWAMPRequest when proper InterProcessRPCRequestSchema param passed to "workerMessage" handler', () => {
-				const onWorkerMessageHandler = fakeSCServer.on.getCalls()[1].args[1];
-				onWorkerMessageHandler(0, validInterProcessRPCRequest);
-				expect(masterWAMPServer.processWAMPRequest.called).to.be.ok();
+			describe('workerMessage', () => {
+				let onWorkerMessageHandler;
+
+				beforeEach(() => {
+					onWorkerMessageHandler = fakeSCServer.on.getCalls()[1].args[1];
+				});
+
+				it('should call processWAMPRequest when proper InterProcessRPCRequestSchema param passed to "workerMessage" handler', () => {
+					onWorkerMessageHandler(validWorkerId, validInterProcessRPCRequest);
+					expect(masterWAMPServer.processWAMPRequest.called).to.be.ok();
+				});
+
+				it('should call processWAMPRequest when proper MasterWAMPRequest param passed to "workerMessage" handler', () => {
+					onWorkerMessageHandler(validWorkerId, validMasterWAMPRequest);
+					expect(masterWAMPServer.processWAMPRequest.called).to.be.ok();
+				});
+
+				it('should call processWAMPRequest when proper MasterWAMPRequestSchema with received request', () => {
+					onWorkerMessageHandler(validWorkerId, validMasterWAMPRequest);
+					expect(masterWAMPServer.processWAMPRequest.calledWith(validMasterWAMPRequest)).to.be.ok();
+				});
+
+				it('should not call processWAMPRequest when invalid MasterWAMPRequestSchema passed', () => {
+					const invalidMasterWAMPCall = Object.assign({}, validMasterWAMPRequest, { type: 'invalid' });
+					onWorkerMessageHandler(validWorkerId, invalidMasterWAMPCall);
+					expect(masterWAMPServer.processWAMPRequest.called).not.to.be.ok();
+				});
+
+				it('should not call processWAMPRequest when empty request passed', () => {
+					onWorkerMessageHandler(validWorkerId, null);
+					expect(masterWAMPServer.processWAMPRequest.called).not.to.be.ok();
+				});
 			});
 
-			it('should call processWAMPRequest when proper MasterWAMPRequest param passed to "workerMessage" handler', () => {
-				const onWorkerMessageHandler = fakeSCServer.on.getCalls()[1].args[1];
-				onWorkerMessageHandler(0, validMasterWAMPRequest);
-				expect(masterWAMPServer.processWAMPRequest.called).to.be.ok();
+			describe('workerStart', () => {
+				let onWorkerStartHandler;
+				let validWorker;
+
+				beforeEach(() => {
+					onWorkerStartHandler = fakeSCServer.on.getCalls()[0].args[1];
+					validWorker = { id: validWorkerId };
+					sinon.stub(masterWAMPServer, 'reply');
+				});
+
+				after(() => {
+					masterWAMPServer.reply.restore();
+				});
+
+				it('should call reply function with null as socket with validWorker', () => {
+					onWorkerStartHandler(validWorker);
+					expect(masterWAMPServer.reply.calledWith(null)).to.be.ok();
+				});
+
+				it('should call reply function with valid MasterConfigRequestSchema', () => {
+					onWorkerStartHandler(validWorker);
+					expect(masterWAMPServer.reply.args[0][1]).eql({
+						registeredEvents: [],
+						config: {},
+						type: '/MasterConfigRequestSchema',
+						workerId: validWorkerId,
+					}).to.be.ok();
+				});
 			});
 
-			it('should call processWAMPRequest when proper MasterWAMPRequestSchema with received request', () => {
-				const onWorkerMessageHandler = fakeSCServer.on.getCalls()[1].args[1];
-				onWorkerMessageHandler(0, validMasterWAMPRequest);
-				expect(masterWAMPServer.processWAMPRequest.calledWith(validMasterWAMPRequest)).to.be.ok();
-			});
+			describe('workerExit', () => {
+				let onWorkerExitHandler;
+				let validWorker;
 
-			it('should not call processWAMPRequest when invalid MasterWAMPRequestSchema passed', () => {
-				const onWorkerMessageHandler = fakeSCServer.on.getCalls()[1].args[1];
-				const invalidMasterWAMPCall = Object.assign({}, validMasterWAMPRequest, { type: 'invalid' });
-				onWorkerMessageHandler(0, invalidMasterWAMPCall);
-				expect(masterWAMPServer.processWAMPRequest.called).not.to.be.ok();
-			});
+				beforeEach(() => {
+					onWorkerExitHandler = fakeSCServer.on.getCalls()[2].args[1];
+					validWorker = { id: validWorkerId };
+					sinon.stub(masterWAMPServer, 'reply');
+				});
 
-			it('should not call processWAMPRequest when empty request passed', () => {
-				const onWorkerMessageHandler = fakeSCServer.on.getCalls()[1].args[1];
-				onWorkerMessageHandler(0, null);
-				expect(masterWAMPServer.processWAMPRequest.called).not.to.be.ok();
+				after(() => {
+					masterWAMPServer.reply.restore();
+				});
+
+				it('should not modify empty workerIndices map', () => {
+					onWorkerExitHandler(validWorker);
+					expect(masterWAMPServer.workerIndices).to.be.empty();
+				});
+
+				it('should remove the worker index from the workerIndices array if added previously', () => {
+					masterWAMPServer.workerIndices = [0];
+					onWorkerExitHandler(validWorker);
+					expect(masterWAMPServer.workerIndices).to.be.empty();
+				});
+
+				it('should remove the worker index from beginning of the workerIndices array if added previously', () => {
+					masterWAMPServer.workerIndices = [0, 1, 2];
+					onWorkerExitHandler(validWorker);
+					expect(masterWAMPServer.workerIndices).to.eql([1, 2]);
+				});
+
+				it('should remove the worker index from the middle of the workerIndices array if added previously', () => {
+					masterWAMPServer.workerIndices = [1, 0, 2];
+					onWorkerExitHandler(validWorker);
+					expect(masterWAMPServer.workerIndices).to.eql([1, 2]);
+				});
+
+				it('should remove the worker index from the end of the workerIndices array if added previously', () => {
+					masterWAMPServer.workerIndices = [1, 2, 0];
+					onWorkerExitHandler(validWorker);
+					expect(masterWAMPServer.workerIndices).to.eql([1, 2]);
+				});
 			});
 		});
 	});
 
 	describe('reply', () => {
-		it('should use MasterWAMPServer.reply', () => {
+		let validRequest;
+		let validData;
 
+		beforeEach(() => {
+			validRequest = {
+				workerId: validWorkerId,
+				type: '/MasterWAMPRequest',
+			};
+			validData = { validKey: 'validValue' };
+		});
+
+		it('should invoke socketCluster.sendToWorker with a valid success WAMPResponse', () => {
+			masterWAMPServer.reply(null, validRequest, null, validData);
+			expect(masterWAMPServer.socketCluster.sendToWorker.calledWith(validWorkerId)).to.be.ok();
+			expect(masterWAMPServer.socketCluster.sendToWorker.args[0][1]).eql({
+				workerId: 0,
+				success: true,
+				data: {
+					validKey: 'validValue',
+				},
+				type: '/WAMPResponse',
+				error: null,
+			});
+		});
+
+		it('should invoke socketCluster.sendToWorker with a valid error WAMPResponse in case of passing error message', () => {
+			masterWAMPServer.reply(null, validRequest, 'Custom error', validData);
+			expect(masterWAMPServer.socketCluster.sendToWorker.calledWith(validWorkerId)).to.be.ok();
+			expect(masterWAMPServer.socketCluster.sendToWorker.args[0][1]).eql({
+				workerId: 0,
+				success: false,
+				data: {
+					validKey: 'validValue',
+				},
+				type: '/WAMPResponse',
+				error: 'Custom error',
+			});
 		});
 	});
 });

--- a/MasterWAMPServer.spec.js
+++ b/MasterWAMPServer.spec.js
@@ -131,15 +131,16 @@ describe('MasterWAMPServer', () => {
 			describe('workerExit', () => {
 				let onWorkerExitHandler;
 				let validWorker;
+				let masterWAMPServerReplyStub;
 
 				beforeEach(() => {
 					onWorkerExitHandler = fakeSCServer.on.getCalls()[2].args[1];
 					validWorker = { id: validWorkerId };
-					masterWAMPServer.reply = sinon.stub(masterWAMPServer, 'reply');
+					masterWAMPServerReplyStub = sinon.stub(masterWAMPServer, 'reply');
 				});
 
 				after(() => {
-					masterWAMPServer.reply.restore();
+					masterWAMPServerReplyStub.restore();
 				});
 
 				it('should not modify empty workerIndices array', () => {

--- a/SlaveWAMPServer.js
+++ b/SlaveWAMPServer.js
@@ -71,6 +71,7 @@ class SlaveWAMPServer extends WAMPServer {
 	 * @param {*} data
 	 * @param {string} socketId
 	 * @param {Function} cb
+	 * @returns {undefined}
 	 */
 	sendToMaster(procedure, data, socketId, cb) {
 		const req = SlaveWAMPServer.normalizeRequest({
@@ -89,6 +90,7 @@ class SlaveWAMPServer extends WAMPServer {
 	/**
 	 * @param {WAMPRequestSchema} request
 	 * @param {Object} socket
+	 * @returns {undefined}
 	 */
 	processWAMPRequest(request, socket) {
 		if (v.validate(request, schemas.WAMPRequestSchema).valid) {
@@ -108,6 +110,7 @@ class SlaveWAMPServer extends WAMPServer {
 	/**
 	 * @param {string} socketId
 	 * @returns {boolean}
+	 * @returns {undefined}
 	 */
 	onSocketDisconnect(socketId) {
 		return delete this.interProcessRPC[socketId];
@@ -116,6 +119,7 @@ class SlaveWAMPServer extends WAMPServer {
 	/**
 	 * @param {InterProcessRPCRequestSchema}[request={}] request
 	 * @param {Function} cb
+	 * @returns {undefined}
 	 */
 	saveCall(request = {}, cb) {
 		if (!request.socketId || !request.procedure || !request.signature) {
@@ -129,13 +133,16 @@ class SlaveWAMPServer extends WAMPServer {
 
 	/**
 	 * @param {InterProcessRPCRequestSchema}[request={}] request
+	 * @returns {InterProcessRPCRequestSchema|false}
 	 */
 	getCall(request = {}) {
 		return get(this.interProcessRPC, `${request.socketId}.${request.procedure}.${request.signature}`, false);
 	}
 
+
 	/**
 	 * @param {InterProcessRPCResponseSchema}[request={}] request
+	 * @returns {boolean}
 	 */
 	deleteCall(request = {}) {
 		if (!request.socketId || !request.procedure || !request.signature) {
@@ -149,6 +156,7 @@ class SlaveWAMPServer extends WAMPServer {
 
 	/**
 	 * @param {Map<RPCEndpoint>} endpoints
+	 * @returns {undefined}
 	 */
 	reassignRPCSlaveEndpoints(endpoints) {
 		this.endpoints.slaveRpc = endpoints;
@@ -156,6 +164,7 @@ class SlaveWAMPServer extends WAMPServer {
 
 	/**
 	 * @param {Map<RPCEndpoint>} endpoints
+	 * @returns {undefined}
 	 */
 	registerRPCSlaveEndpoints(endpoints) {
 		this.endpoints.slaveRpc = Object.assign(this.endpoints.slaveRpc, endpoints);

--- a/SlaveWAMPServer.js
+++ b/SlaveWAMPServer.js
@@ -110,7 +110,6 @@ class SlaveWAMPServer extends WAMPServer {
 	/**
 	 * @param {string} socketId
 	 * @returns {boolean}
-	 * @returns {undefined}
 	 */
 	onSocketDisconnect(socketId) {
 		return delete this.interProcessRPC[socketId];
@@ -123,7 +122,7 @@ class SlaveWAMPServer extends WAMPServer {
 	 */
 	saveCall(request = {}, cb) {
 		if (!request.socketId || !request.procedure || !request.signature) {
-			throw new Error('Cannot save a call for wrong InterProcessRPCRequest request');
+			throw new Error(`Cannot save a call for wrong InterProcessRPCRequest request: ${JSON.stringify(request)}`);
 		}
 		if (!cb) {
 			throw new Error('Cannot save a call without callback');
@@ -133,7 +132,7 @@ class SlaveWAMPServer extends WAMPServer {
 
 	/**
 	 * @param {InterProcessRPCRequestSchema}[request={}] request
-	 * @returns {InterProcessRPCRequestSchema|false}
+	 * @returns {Function|false}
 	 */
 	getCall(request = {}) {
 		return get(this.interProcessRPC, `${request.socketId}.${request.procedure}.${request.signature}`, false);
@@ -146,10 +145,10 @@ class SlaveWAMPServer extends WAMPServer {
 	 */
 	deleteCall(request = {}) {
 		if (!request.socketId || !request.procedure || !request.signature) {
-			throw new Error('Cannot delete a call for wrong InterProcessRPCRequest request');
+			throw new Error(`Cannot delete a call for wrong InterProcessRPCRequest request: ${JSON.stringify(request)}`);
 		}
 		if (!this.getCall(request)) {
-			throw new Error(`There is no internal requests registered for socket: ${request.socketId}, procedure: ${request.procedure} with signature ${request.signature}`);
+			throw new Error(`There are no internal requests registered for socket: ${request.socketId}, procedure: ${request.procedure} with signature ${request.signature}`);
 		}
 		return delete this.interProcessRPC[request.socketId][request.procedure][request.signature];
 	}

--- a/SlaveWAMPServer.js
+++ b/SlaveWAMPServer.js
@@ -118,7 +118,7 @@ class SlaveWAMPServer extends WAMPServer {
 	/**
 	 * @param {InterProcessRPCRequestSchema}[request={}] request
 	 * @param {Function} cb
-	 * @returns {undefined}
+	 * @returns {Object}
 	 */
 	saveCall(request = {}, cb) {
 		if (!request.socketId || !request.procedure || !request.signature) {

--- a/SlaveWAMPServer.js
+++ b/SlaveWAMPServer.js
@@ -51,8 +51,8 @@ class SlaveWAMPServer extends WAMPServer {
 	}
 
 	/**
-	 * @param {object} request
-	 * @returns {{}}
+	 * @param {Object}[request={}] request
+	 * @returns {WAMPRequestSchema}
 	 */
 	static normalizeRequest(request = {}) {
 		if (!request.procedure || typeof request.procedure !== 'string') {
@@ -88,8 +88,7 @@ class SlaveWAMPServer extends WAMPServer {
 
 	/**
 	 * @param {WAMPRequestSchema} request
-	 * @param {object} socket
-	 * @returns {*}
+	 * @param {Object} socket
 	 */
 	processWAMPRequest(request, socket) {
 		if (v.validate(request, schemas.WAMPRequestSchema).valid) {
@@ -114,9 +113,8 @@ class SlaveWAMPServer extends WAMPServer {
 		return delete this.interProcessRPC[socketId];
 	}
 
-
 	/**
-	 * @param {InterProcessRPCRequestSchema} request
+	 * @param {InterProcessRPCRequestSchema}[request={}] request
 	 * @param {Function} cb
 	 */
 	saveCall(request = {}, cb) {
@@ -130,14 +128,14 @@ class SlaveWAMPServer extends WAMPServer {
 	}
 
 	/**
-	 * @param {InterProcessRPCRequestSchema} request
+	 * @param {InterProcessRPCRequestSchema}[request={}] request
 	 */
 	getCall(request = {}) {
 		return get(this.interProcessRPC, `${request.socketId}.${request.procedure}.${request.signature}`, false);
 	}
 
 	/**
-	 * @param {InterProcessRPCResponseSchema} request
+	 * @param {InterProcessRPCResponseSchema}[request={}] request
 	 */
 	deleteCall(request = {}) {
 		if (!request.socketId || !request.procedure || !request.signature) {

--- a/SlaveWAMPServer.js
+++ b/SlaveWAMPServer.js
@@ -116,13 +116,22 @@ class SlaveWAMPServer extends WAMPServer {
 	}
 
 	/**
-	 * @param {InterProcessRPCRequestSchema}[request={}] request
+	 * @param {InterProcessRPCRequestSchema} request
 	 * @param {Function} cb
 	 * @returns {Object}
 	 */
-	saveCall(request = {}, cb) {
-		if (!request.socketId || !request.procedure || !request.signature) {
-			throw new Error(`Cannot save a call for wrong InterProcessRPCRequest request: ${JSON.stringify(request)}`);
+	saveCall(request, cb) {
+		if (!request) {
+			throw new Error('Internal error while attempting to save InterProcessRPCRequest: empty request');
+		}
+		if (!request.socketId) {
+			throw new Error('Internal error while attempting to save InterProcessRPCRequest: missing socketId');
+		}
+		if (!request.procedure) {
+			throw new Error('Internal error while attempting to save InterProcessRPCRequest: missing procedure');
+		}
+		if (!request.signature) {
+			throw new Error('Internal error while attempting to save InterProcessRPCRequest: missing signature');
 		}
 		if (!cb) {
 			throw new Error('Cannot save a call without callback');
@@ -140,12 +149,21 @@ class SlaveWAMPServer extends WAMPServer {
 
 
 	/**
-	 * @param {InterProcessRPCResponseSchema}[request={}] request
+	 * @param {InterProcessRPCResponseSchema} request
 	 * @returns {boolean}
 	 */
-	deleteCall(request = {}) {
-		if (!request.socketId || !request.procedure || !request.signature) {
-			throw new Error(`Cannot delete a call for wrong InterProcessRPCRequest request: ${JSON.stringify(request)}`);
+	deleteCall(request) {
+		if (!request) {
+			throw new Error('Internal error while attempting to delete InterProcessRPCRequest: empty request');
+		}
+		if (!request.socketId) {
+			throw new Error('Internal error while attempting to delete InterProcessRPCRequest: missing socketId');
+		}
+		if (!request.procedure) {
+			throw new Error('Internal error while attempting to delete InterProcessRPCRequest: missing procedure');
+		}
+		if (!request.signature) {
+			throw new Error('Internal error while attempting to delete InterProcessRPCRequest: missing signature');
 		}
 		if (!this.getCall(request)) {
 			throw new Error(`There are no internal requests registered for socket: ${request.socketId}, procedure: ${request.procedure} with signature ${request.signature}`);

--- a/SlaveWAMPServer.spec.js
+++ b/SlaveWAMPServer.spec.js
@@ -224,12 +224,14 @@ describe('SlaveWAMPServer', () => {
 	});
 
 	describe('sendToMaster', () => {
+		let mathRandomStub;
+
 		before(() => {
-			Math.random = sinon.stub(Math, 'random').returns(0);
+			mathRandomStub = sinon.stub(Math, 'random').returns(0);
 		});
 
 		after(() => {
-			Math.random.restore();
+			mathRandomStub.restore();
 		});
 
 		it('should pass correct InterProcessRPCRequestSchema compatible request to sendToMaster function', () => {

--- a/SlaveWAMPServer.spec.js
+++ b/SlaveWAMPServer.spec.js
@@ -273,7 +273,7 @@ describe('SlaveWAMPServer', () => {
 
 	describe('saveCall', () => {
 		it('should throw an error when invoked without arguments', () => {
-			expect(slaveWAMPServer.saveCall).to.throw('Cannot save a call for wrong InterProcessRPCRequest request');
+			expect(slaveWAMPServer.saveCall).to.throw('Internal error while attempting to save InterProcessRPCRequest: empty request');
 			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
@@ -281,7 +281,7 @@ describe('SlaveWAMPServer', () => {
 			delete validRequest.socketId;
 			expect(() => {
 				slaveWAMPServer.saveCall(validRequest, validCb);
-			}).to.throw('Cannot save a call for wrong InterProcessRPCRequest request');
+			}).to.throw('Internal error while attempting to save InterProcessRPCRequest: missing socketId');
 			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
@@ -289,7 +289,7 @@ describe('SlaveWAMPServer', () => {
 			delete validRequest.procedure;
 			expect(() => {
 				slaveWAMPServer.saveCall(validRequest, validCb);
-			}).to.throw('Cannot save a call for wrong InterProcessRPCRequest request');
+			}).to.throw('Internal error while attempting to save InterProcessRPCRequest: missing procedure');
 			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
@@ -297,7 +297,7 @@ describe('SlaveWAMPServer', () => {
 			delete validRequest.signature;
 			expect(() => {
 				slaveWAMPServer.saveCall(validRequest, validCb);
-			}).to.throw('Cannot save a call for wrong InterProcessRPCRequest request');
+			}).to.throw('Internal error while attempting to save InterProcessRPCRequest: missing signature');
 			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
@@ -331,7 +331,7 @@ describe('SlaveWAMPServer', () => {
 
 	describe('deleteCall', () => {
 		it('should throw an error when invoked without arguments', () => {
-			expect(slaveWAMPServer.deleteCall).to.throw('Cannot delete a call for wrong InterProcessRPCRequest request');
+			expect(slaveWAMPServer.deleteCall).to.throw('Internal error while attempting to delete InterProcessRPCRequest: empty request');
 			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
@@ -339,7 +339,7 @@ describe('SlaveWAMPServer', () => {
 			delete validRequest.socketId;
 			expect(() => {
 				slaveWAMPServer.deleteCall(validRequest);
-			}).to.throw('Cannot delete a call for wrong InterProcessRPCRequest request');
+			}).to.throw('Internal error while attempting to delete InterProcessRPCRequest: missing socketId');
 			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
@@ -347,7 +347,7 @@ describe('SlaveWAMPServer', () => {
 			delete validRequest.procedure;
 			expect(() => {
 				slaveWAMPServer.deleteCall(validRequest);
-			}).to.throw('Cannot delete a call for wrong InterProcessRPCRequest request');
+			}).to.throw('Internal error while attempting to delete InterProcessRPCRequest: missing procedure');
 			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
@@ -355,7 +355,7 @@ describe('SlaveWAMPServer', () => {
 			delete validRequest.signature;
 			expect(() => {
 				slaveWAMPServer.deleteCall(validRequest);
-			}).to.throw('Cannot delete a call for wrong InterProcessRPCRequest request');
+			}).to.throw('Internal error while attempting to delete InterProcessRPCRequest: missing signature');
 			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 

--- a/SlaveWAMPServer.spec.js
+++ b/SlaveWAMPServer.spec.js
@@ -225,7 +225,7 @@ describe('SlaveWAMPServer', () => {
 
 	describe('sendToMaster', () => {
 		before(() => {
-			sinon.stub(Math, 'random').returns(0);
+			Math.random = sinon.stub(Math, 'random').returns(0);
 		});
 
 		after(() => {

--- a/SlaveWAMPServer.spec.js
+++ b/SlaveWAMPServer.spec.js
@@ -5,17 +5,8 @@ const SlaveWAMPServer = require('./SlaveWAMPServer');
 
 const { expect } = require('./testSetup.spec');
 
-let clock;
-
-before(() => {
-	clock = sinon.useFakeTimers(new Date(2020, 1, 1).getTime());
-});
-
-after(() => {
-	clock.restore();
-});
-
 describe('SlaveWAMPServer', () => {
+	let clock;
 	let workerMock;
 	let slaveWAMPServer;
 	let validData;
@@ -53,6 +44,14 @@ describe('SlaveWAMPServer', () => {
 		};
 	});
 
+	before(() => {
+		clock = sinon.useFakeTimers(new Date(2020, 1, 1).getTime());
+	});
+
+	after(() => {
+		clock.restore();
+	});
+
 	describe('constructor', () => {
 		it('create SlaveWAMPServer with worker field', () => {
 			expect(slaveWAMPServer).to.have.property('worker').to.be.a('object').and.to.have.property('id').equal(0);
@@ -72,7 +71,7 @@ describe('SlaveWAMPServer', () => {
 
 		it('create SlaveWAMPServer and register event listener from master process', () => {
 			expect(workerMock.on.calledOnce).to.be.true();
-			expect(workerMock.on.calledWith('masterMessage')).to.be.ok();
+			expect(workerMock.on.calledWith('masterMessage')).to.be.true();
 		});
 	});
 
@@ -174,7 +173,7 @@ describe('SlaveWAMPServer', () => {
 		it('should pass request forward to master if procedure is not registered in SlaveWAMPServer', () => {
 			slaveWAMPServer.processWAMPRequest(validWAMPRequest, socketMock);
 			expect(workerMock.sendToMaster.calledOnce).to.be.true();
-			expect(workerMock.sendToMaster.calledWith(validSlaveToMasterRequest)).to.be.ok();
+			expect(workerMock.sendToMaster.calledWith(validSlaveToMasterRequest)).to.be.true();
 		});
 
 		it('should invoke procedure on SlaveWAMPServer if registered before', () => {
@@ -187,9 +186,9 @@ describe('SlaveWAMPServer', () => {
 				type: '/WAMPRequest',
 				socketId: 'validSocketId',
 				workerId: 0,
-			})).to.be.ok();
+			})).to.be.true();
 
-			expect(workerMock.sendToMaster.called).not.to.be.ok();
+			expect(workerMock.sendToMaster.called).not.to.be.true();
 		});
 
 		it('should invoke procedure on SlaveWAMPServer if reassigned before', () => {
@@ -202,9 +201,9 @@ describe('SlaveWAMPServer', () => {
 				type: '/WAMPRequest',
 				socketId: 'validSocketId',
 				workerId: 0,
-			})).to.be.ok();
+			})).to.be.true();
 
-			expect(workerMock.sendToMaster.called).not.to.be.ok();
+			expect(workerMock.sendToMaster.called).not.to.be.true();
 		});
 
 		it('should invoke procedure on SlaveWAMPServer if it was registered on both WAMPServer and SlaveWAMPServer', () => {
@@ -218,9 +217,9 @@ describe('SlaveWAMPServer', () => {
 				type: '/WAMPRequest',
 				socketId: 'validSocketId',
 				workerId: 0,
-			})).to.be.ok();
+			})).to.be.true();
 
-			expect(workerMock.sendToMaster.called).not.to.be.ok();
+			expect(workerMock.sendToMaster.called).not.to.be.true();
 		});
 	});
 
@@ -243,7 +242,7 @@ describe('SlaveWAMPServer', () => {
 				socketId: validSocketId,
 				workerId: 0,
 				signature: validSignature,
-			})).to.be.ok();
+			})).to.be.true();
 		});
 
 		it('should pass create a new entry in interProcessRPC map', () => {
@@ -314,7 +313,7 @@ describe('SlaveWAMPServer', () => {
 
 		it('should create multiple entries in interProcessRPC for multiple valid requests', () => {
 			slaveWAMPServer.saveCall(validRequest, validCb);
-			const validRequestB = validRequest;
+			const validRequestB = Object.assign({}, validRequest);
 			validRequestB.socketId += 'B';
 			validRequestB.procedure += 'B';
 			validRequestB.signature += 'B';
@@ -361,7 +360,7 @@ describe('SlaveWAMPServer', () => {
 		it('should throw an error when entry does not exist', () => {
 			expect(() => {
 				slaveWAMPServer.deleteCall(validRequest);
-			}).to.throw(`There is no internal requests registered for socket: ${validSocketId}, procedure: ${validProcedure} with signature ${validSignature}`);
+			}).to.throw(`There are no internal requests registered for socket: ${validSocketId}, procedure: ${validProcedure} with signature ${validSignature}`);
 		});
 
 		describe('when call exists', () => {
@@ -378,11 +377,11 @@ describe('SlaveWAMPServer', () => {
 
 	describe('getCall', () => {
 		it('should return false when invoked without arguments', () => {
-			expect(slaveWAMPServer.getCall()).to.be.not.ok();
+			expect(slaveWAMPServer.getCall()).to.be.false();
 		});
 
 		it('should return false when a call does not exist', () => {
-			expect(slaveWAMPServer.getCall(validRequest)).to.be.not.ok();
+			expect(slaveWAMPServer.getCall(validRequest)).to.be.false();
 		});
 
 		describe('when call exists', () => {
@@ -392,21 +391,21 @@ describe('SlaveWAMPServer', () => {
 
 			it('should return false when invoked without socket id', () => {
 				delete validRequest.socketId;
-				expect(slaveWAMPServer.getCall()).to.be.not.ok();
+				expect(slaveWAMPServer.getCall()).to.be.false();
 			});
 
 			it('should return false when invoked without procedure', () => {
 				delete validRequest.procedure;
-				expect(slaveWAMPServer.getCall()).to.be.not.ok();
+				expect(slaveWAMPServer.getCall()).to.be.false();
 			});
 
 			it('should return false when invoked without signature', () => {
 				delete validRequest.signature;
-				expect(slaveWAMPServer.getCall()).to.be.not.ok();
+				expect(slaveWAMPServer.getCall()).to.be.false();
 			});
 
-			it('should return true when invoked with valid request', () => {
-				expect(slaveWAMPServer.getCall(validRequest)).to.be.ok();
+			it('should return valid callback when invoked with valid request', () => {
+				expect(slaveWAMPServer.getCall(validRequest)).to.be.a('function');
 			});
 		});
 	});

--- a/SlaveWAMPServer.spec.js
+++ b/SlaveWAMPServer.spec.js
@@ -17,7 +17,14 @@ after(() => {
 
 describe('SlaveWAMPServer', () => {
 	let workerMock;
-	let slaveWampServer;
+	let slaveWAMPServer;
+	let validData;
+	let validRequest;
+	let validSignature;
+	let validInterProcessRPCEntry;
+	const validProcedure = 'validProcedure';
+	const validSocketId = 'validSocketId';
+	const validCb = sinon.spy();
 
 	beforeEach(() => {
 		workerMock = {
@@ -28,46 +35,49 @@ describe('SlaveWAMPServer', () => {
 				clients: {},
 			},
 		};
-		slaveWampServer = new SlaveWAMPServer(workerMock);
+		validCb.reset();
+		slaveWAMPServer = new SlaveWAMPServer(workerMock);
+		validSignature = `${new Date().getTime()}_0`;
+		validRequest = {
+			socketId: validSocketId,
+			procedure: validProcedure,
+			signature: validSignature,
+		};
+		validData = { validKey: 'validValue' };
+		validInterProcessRPCEntry = {
+			[validSocketId]: {
+				[validProcedure]: {
+					[validSignature]: () => {},
+				},
+			},
+		};
 	});
 
 	describe('constructor', () => {
 		it('create SlaveWAMPServer with worker field', () => {
-			const slaveWAMPServer = new SlaveWAMPServer(workerMock);
 			expect(slaveWAMPServer).to.have.property('worker').to.be.a('object').and.to.have.property('id').equal(0);
 		});
 
 		it('create SlaveWAMPServer with RPCCalls field', () => {
-			const slaveWAMPServer = new SlaveWAMPServer(workerMock);
 			expect(slaveWAMPServer).to.have.property('interProcessRPC').to.be.a('object').and.to.be.empty();
 		});
 
 		it('create SlaveWAMPServer with sockets field', () => {
-			const slaveWAMPServer = new SlaveWAMPServer(workerMock);
 			expect(slaveWAMPServer).to.have.property('sockets').to.be.a('object').and.to.be.empty();
 		});
 
 		it('create SlaveWAMPServer with sockets field', () => {
-			const slaveWAMPServer = new SlaveWAMPServer(workerMock);
 			expect(slaveWAMPServer).to.have.property('sockets').to.be.a('object').and.to.be.empty();
 		});
 
 		it('create SlaveWAMPServer and register event listener from master process', () => {
-			expect(workerMock.on.calledOnce).to.be.ok();
+			expect(workerMock.on.calledOnce).to.be.true();
 			expect(workerMock.on.calledWith('masterMessage')).to.be.ok();
 		});
 	});
 
 	describe('normalizeRequest', () => {
-		let validRequest;
 		const normalizeRequest = SlaveWAMPServer.normalizeRequest;
-
-		beforeEach(() => {
-			validRequest = {
-				socketId: 'validSocketId',
-				procedure: 'validProcedure',
-			};
-		});
 
 		it('should throw an exception when invoked with empty object', () => {
 			expect(normalizeRequest.bind(null, {})).to.throw();
@@ -138,7 +148,7 @@ describe('SlaveWAMPServer', () => {
 
 	describe('processWAMPRequest', () => {
 		let socketMock;
-		let validRequest;
+		let validWAMPRequest;
 		let validSlaveToMasterRequest;
 
 		beforeEach(() => {
@@ -148,10 +158,7 @@ describe('SlaveWAMPServer', () => {
 				send: sinon.spy(),
 			};
 
-			socketMock.on.reset();
-			socketMock.send.reset();
-
-			validRequest = {
+			validWAMPRequest = {
 				procedure: 'procedureName',
 				type: '/WAMPRequest',
 			};
@@ -165,16 +172,16 @@ describe('SlaveWAMPServer', () => {
 		});
 
 		it('should pass request forward to master if procedure is not registered in SlaveWAMPServer', () => {
-			slaveWampServer.processWAMPRequest(validRequest, socketMock);
-			expect(workerMock.sendToMaster.calledOnce).to.be.ok();
+			slaveWAMPServer.processWAMPRequest(validWAMPRequest, socketMock);
+			expect(workerMock.sendToMaster.calledOnce).to.be.true();
 			expect(workerMock.sendToMaster.calledWith(validSlaveToMasterRequest)).to.be.ok();
 		});
 
 		it('should invoke procedure on SlaveWAMPServer if registered before', () => {
 			const endpoint = { procedureName: sinon.spy() };
-			slaveWampServer.registerRPCSlaveEndpoints(endpoint);
-			slaveWampServer.processWAMPRequest(validRequest, socketMock);
-			expect(endpoint.procedureName.calledOnce).to.be.ok();
+			slaveWAMPServer.registerRPCSlaveEndpoints(endpoint);
+			slaveWAMPServer.processWAMPRequest(validWAMPRequest, socketMock);
+			expect(endpoint.procedureName.calledOnce).to.be.true();
 			expect(endpoint.procedureName.calledWith({
 				procedure: 'procedureName',
 				type: '/WAMPRequest',
@@ -187,9 +194,9 @@ describe('SlaveWAMPServer', () => {
 
 		it('should invoke procedure on SlaveWAMPServer if reassigned before', () => {
 			const endpoint = { procedureName: sinon.spy() };
-			slaveWampServer.reassignRPCSlaveEndpoints(endpoint);
-			slaveWampServer.processWAMPRequest(validRequest, socketMock);
-			expect(endpoint.procedureName.calledOnce).to.be.ok();
+			slaveWAMPServer.reassignRPCSlaveEndpoints(endpoint);
+			slaveWAMPServer.processWAMPRequest(validWAMPRequest, socketMock);
+			expect(endpoint.procedureName.calledOnce).to.be.true();
 			expect(endpoint.procedureName.calledWith({
 				procedure: 'procedureName',
 				type: '/WAMPRequest',
@@ -202,10 +209,10 @@ describe('SlaveWAMPServer', () => {
 
 		it('should invoke procedure on SlaveWAMPServer if it was registered on both WAMPServer and SlaveWAMPServer', () => {
 			const endpoint = { procedureName: sinon.spy() };
-			slaveWampServer.registerRPCEndpoints(endpoint);
-			slaveWampServer.registerRPCSlaveEndpoints(endpoint);
-			slaveWampServer.processWAMPRequest(validRequest, socketMock);
-			expect(endpoint.procedureName.calledOnce).to.be.ok();
+			slaveWAMPServer.registerRPCEndpoints(endpoint);
+			slaveWAMPServer.registerRPCSlaveEndpoints(endpoint);
+			slaveWAMPServer.processWAMPRequest(validWAMPRequest, socketMock);
+			expect(endpoint.procedureName.calledOnce).to.be.true();
 			expect(endpoint.procedureName.calledWith({
 				procedure: 'procedureName',
 				type: '/WAMPRequest',
@@ -218,20 +225,6 @@ describe('SlaveWAMPServer', () => {
 	});
 
 	describe('sendToMaster', () => {
-		let validProcedure;
-		let validData;
-		let validSocketId;
-		let validSignature;
-		const actionCb = sinon.spy();
-
-		beforeEach(() => {
-			actionCb.reset();
-			validProcedure = 'validProcedure';
-			validData = { validKey: 'validValue' };
-			validSocketId = 'validSocketId';
-			validSignature = `${new Date().getTime()}_0`;
-		});
-
 		before(() => {
 			sinon.stub(Math, 'random').returns(0);
 		});
@@ -241,8 +234,8 @@ describe('SlaveWAMPServer', () => {
 		});
 
 		it('should pass correct InterProcessRPCRequestSchema compatible request to sendToMaster function', () => {
-			slaveWampServer.sendToMaster(validProcedure, validData, validSocketId, actionCb);
-			expect(workerMock.sendToMaster.calledOnce).to.be.ok();
+			slaveWAMPServer.sendToMaster(validProcedure, validData, validSocketId, validCb);
+			expect(workerMock.sendToMaster.calledOnce).to.be.true();
 			expect(workerMock.sendToMaster.calledWith({
 				type: '/InterProcessRPCRequestSchema',
 				procedure: validProcedure,
@@ -254,246 +247,166 @@ describe('SlaveWAMPServer', () => {
 		});
 
 		it('should pass create a new entry in interProcessRPC map', () => {
-			slaveWampServer.sendToMaster(validProcedure, validData, validSocketId, actionCb);
-			expect(slaveWampServer.interProcessRPC).to.have.property(validSocketId);
-			expect(slaveWampServer.interProcessRPC[validSocketId]).to.have.property(validProcedure);
-			expect(slaveWampServer.interProcessRPC[validSocketId][validProcedure]).to.have.property(validSignature).to.be.a('function');
+			slaveWAMPServer.sendToMaster(validProcedure, validData, validSocketId, validCb);
+			expect(slaveWAMPServer.interProcessRPC).to.have.nested.property(`${validSocketId}.${validProcedure}.${validSignature}`).to.be.a('function');
 		});
 	});
 
 	describe('onSocketDisconnect', () => {
-		let validSocketId;
-		let validProcedure;
-		let validSignature;
-
-		beforeEach(() => {
-			validSocketId = 'validSocketId';
-			validProcedure = 'validProcedure';
-			validSignature = 'validSignature';
-		});
-
 		it('should leave interProcessRPC in initial state when invoked without arguments', () => {
-			slaveWampServer.onSocketDisconnect();
-			expect(slaveWampServer.interProcessRPC).to.be.empty();
+			slaveWAMPServer.onSocketDisconnect();
+			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
 		it('should leave interProcessRPC in initial state when entry does not exist', () => {
-			slaveWampServer.onSocketDisconnect(validSocketId);
-			expect(slaveWampServer.interProcessRPC).to.be.empty();
+			slaveWAMPServer.onSocketDisconnect(validSocketId);
+			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
 		it('should remove existing entry from interProcessRPC', () => {
-			slaveWampServer.interProcessRPC = {
-				[validSocketId]: {
-					[validProcedure]: {
-						[validSignature]: () => {},
-					},
-				},
-			};
-			slaveWampServer.onSocketDisconnect(validSocketId);
-			expect(slaveWampServer.interProcessRPC).to.be.empty();
+			slaveWAMPServer.interProcessRPC = validInterProcessRPCEntry;
+			slaveWAMPServer.onSocketDisconnect(validSocketId);
+			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 	});
 
 	describe('saveCall', () => {
-		let validSocketId;
-		let validProcedure;
-		let validSignature;
-		let validRequest;
-		let validCb;
-
-		beforeEach(() => {
-			validSocketId = 'validSocketId';
-			validProcedure = 'validProcedure';
-			validSignature = 'validSignature';
-			validRequest = {
-				socketId: validSocketId,
-				procedure: validProcedure,
-				signature: validSignature,
-			};
-			validCb = () => {};
-		});
-
 		it('should throw an error when invoked without arguments', () => {
-			expect(slaveWampServer.saveCall).to.throw('Cannot save a call for wrong InterProcessRPCRequest request');
-			expect(slaveWampServer.interProcessRPC).to.be.empty();
+			expect(slaveWAMPServer.saveCall).to.throw('Cannot save a call for wrong InterProcessRPCRequest request');
+			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
 		it('should throw an error when invoked without socket id', () => {
 			delete validRequest.socketId;
 			expect(() => {
-				slaveWampServer.saveCall(validRequest, validCb);
+				slaveWAMPServer.saveCall(validRequest, validCb);
 			}).to.throw('Cannot save a call for wrong InterProcessRPCRequest request');
-			expect(slaveWampServer.interProcessRPC).to.be.empty();
+			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
 		it('should throw an error when invoked without procedure', () => {
 			delete validRequest.procedure;
 			expect(() => {
-				slaveWampServer.saveCall(validRequest, validCb);
+				slaveWAMPServer.saveCall(validRequest, validCb);
 			}).to.throw('Cannot save a call for wrong InterProcessRPCRequest request');
-			expect(slaveWampServer.interProcessRPC).to.be.empty();
+			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
 		it('should throw an error when invoked without signature', () => {
 			delete validRequest.signature;
 			expect(() => {
-				slaveWampServer.saveCall(validRequest, validCb);
+				slaveWAMPServer.saveCall(validRequest, validCb);
 			}).to.throw('Cannot save a call for wrong InterProcessRPCRequest request');
-			expect(slaveWampServer.interProcessRPC).to.be.empty();
+			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
 		it('should throw an error when invoked without callback', () => {
 			expect(() => {
-				slaveWampServer.saveCall(validRequest);
+				slaveWAMPServer.saveCall(validRequest);
 			}).to.throw('Cannot save a call without callback');
-			expect(slaveWampServer.interProcessRPC).to.be.empty();
+			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
 		it('should create a new entry in interProcessRPC for valid request', () => {
-			slaveWampServer.saveCall(validRequest, validCb);
-			expect(slaveWampServer.interProcessRPC).to.have.nested.property(`${validSocketId}.${validProcedure}.${validSignature}`).to.be.a('function');
+			slaveWAMPServer.saveCall(validRequest, validCb);
+			expect(slaveWAMPServer.interProcessRPC).to.have.nested.property(`${validSocketId}.${validProcedure}.${validSignature}`).to.be.a('function');
 		});
 
 		it('should create multiple entries in interProcessRPC for multiple valid requests', () => {
-			slaveWampServer.saveCall(validRequest, validCb);
+			slaveWAMPServer.saveCall(validRequest, validCb);
 			const validRequestB = validRequest;
 			validRequestB.socketId += 'B';
 			validRequestB.procedure += 'B';
 			validRequestB.signature += 'B';
-			slaveWampServer.saveCall(validRequestB, validCb);
-			expect(slaveWampServer.interProcessRPC)
+			slaveWAMPServer.saveCall(validRequestB, validCb);
+			expect(slaveWAMPServer.interProcessRPC)
 				.to.have.nested.property(`${validSocketId}.${validProcedure}.${validSignature}`)
 				.to.be.a('function');
-			expect(slaveWampServer.interProcessRPC)
+			expect(slaveWAMPServer.interProcessRPC)
 				.to.have.nested.property(`${validRequestB.socketId}.${validRequestB.procedure}.${validRequestB.signature}`)
 				.to.be.a('function');
 		});
 	});
 
 	describe('deleteCall', () => {
-		let validSocketId;
-		let validProcedure;
-		let validSignature;
-		let validRequest;
-
-		beforeEach(() => {
-			validSocketId = 'validSocketId';
-			validProcedure = 'validProcedure';
-			validSignature = 'validSignature';
-			validRequest = {
-				socketId: validSocketId,
-				procedure: validProcedure,
-				signature: validSignature,
-			};
-		});
-
 		it('should throw an error when invoked without arguments', () => {
-			expect(slaveWampServer.deleteCall).to.throw('Cannot delete a call for wrong InterProcessRPCRequest request');
-			expect(slaveWampServer.interProcessRPC).to.be.empty();
+			expect(slaveWAMPServer.deleteCall).to.throw('Cannot delete a call for wrong InterProcessRPCRequest request');
+			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
 		it('should throw an error when invoked without socket id', () => {
 			delete validRequest.socketId;
 			expect(() => {
-				slaveWampServer.deleteCall(validRequest);
+				slaveWAMPServer.deleteCall(validRequest);
 			}).to.throw('Cannot delete a call for wrong InterProcessRPCRequest request');
-			expect(slaveWampServer.interProcessRPC).to.be.empty();
+			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
 		it('should throw an error when invoked without procedure', () => {
 			delete validRequest.procedure;
 			expect(() => {
-				slaveWampServer.deleteCall(validRequest);
+				slaveWAMPServer.deleteCall(validRequest);
 			}).to.throw('Cannot delete a call for wrong InterProcessRPCRequest request');
-			expect(slaveWampServer.interProcessRPC).to.be.empty();
+			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
 		it('should throw an error when invoked without signature', () => {
 			delete validRequest.signature;
 			expect(() => {
-				slaveWampServer.deleteCall(validRequest);
+				slaveWAMPServer.deleteCall(validRequest);
 			}).to.throw('Cannot delete a call for wrong InterProcessRPCRequest request');
-			expect(slaveWampServer.interProcessRPC).to.be.empty();
+			expect(slaveWAMPServer.interProcessRPC).to.be.empty();
 		});
 
 		it('should throw an error when entry does not exist', () => {
 			expect(() => {
-				slaveWampServer.deleteCall(validRequest);
-			}).to.throw('There is no internal requests registered for socket: validSocketId, procedure: validProcedure with signature validSignature');
+				slaveWAMPServer.deleteCall(validRequest);
+			}).to.throw(`There is no internal requests registered for socket: ${validSocketId}, procedure: ${validProcedure} with signature ${validSignature}`);
 		});
 
 		describe('when call exists', () => {
 			beforeEach(() => {
-				slaveWampServer.interProcessRPC = {
-					[validSocketId]: {
-						[validProcedure]: {
-							[validSignature]: () => {},
-						},
-					},
-				};
+				slaveWAMPServer.interProcessRPC = validInterProcessRPCEntry;
 			});
 
 			it('should delete existing signature call for procedure in interProcessRPC', () => {
-				slaveWampServer.deleteCall(validRequest);
-				expect(slaveWampServer.interProcessRPC[validSocketId][validProcedure]).to.be.empty();
+				slaveWAMPServer.deleteCall(validRequest);
+				expect(slaveWAMPServer.interProcessRPC[validSocketId][validProcedure]).to.be.empty();
 			});
 		});
 	});
 
 	describe('getCall', () => {
-		let validSocketId;
-		let validProcedure;
-		let validSignature;
-		let validRequest;
-
-		beforeEach(() => {
-			validSocketId = 'validSocketId';
-			validProcedure = 'validProcedure';
-			validSignature = 'validSignature';
-			validRequest = {
-				socketId: validSocketId,
-				procedure: validProcedure,
-				signature: validSignature,
-			};
-		});
-
 		it('should return false when invoked without arguments', () => {
-			expect(slaveWampServer.getCall()).to.be.not.ok();
+			expect(slaveWAMPServer.getCall()).to.be.not.ok();
 		});
 
 		it('should return false when a call does not exist', () => {
-			expect(slaveWampServer.getCall(validRequest)).to.be.not.ok();
+			expect(slaveWAMPServer.getCall(validRequest)).to.be.not.ok();
 		});
 
 		describe('when call exists', () => {
 			beforeEach(() => {
-				slaveWampServer.interProcessRPC = {
-					[validSocketId]: {
-						[validProcedure]: {
-							[validSignature]: () => {},
-						},
-					},
-				};
+				slaveWAMPServer.interProcessRPC = validInterProcessRPCEntry;
 			});
 
 			it('should return false when invoked without socket id', () => {
 				delete validRequest.socketId;
-				expect(slaveWampServer.getCall()).to.be.not.ok();
+				expect(slaveWAMPServer.getCall()).to.be.not.ok();
 			});
 
 			it('should return false when invoked without procedure', () => {
 				delete validRequest.procedure;
-				expect(slaveWampServer.getCall()).to.be.not.ok();
+				expect(slaveWAMPServer.getCall()).to.be.not.ok();
 			});
 
 			it('should return false when invoked without signature', () => {
 				delete validRequest.signature;
-				expect(slaveWampServer.getCall()).to.be.not.ok();
+				expect(slaveWAMPServer.getCall()).to.be.not.ok();
 			});
 
 			it('should return true when invoked with valid request', () => {
-				expect(slaveWampServer.getCall(validRequest)).to.be.ok();
+				expect(slaveWAMPServer.getCall(validRequest)).to.be.ok();
 			});
 		});
 	});

--- a/SlaveWAMPServer.spec.js
+++ b/SlaveWAMPServer.spec.js
@@ -5,52 +5,63 @@ const SlaveWAMPServer = require('./SlaveWAMPServer');
 
 const { expect } = require('./testSetup.spec');
 
+let clock;
+
+before(() => {
+	clock = sinon.useFakeTimers(new Date(2020, 1, 1).getTime());
+});
+
 describe('SlaveWAMPServer', () => {
+	let workerMock;
+	let slaveWampServer;
+
+	beforeEach(() => {
+		workerMock = {
+			id: 0,
+			on: sinon.spy(),
+			sendToMaster: sinon.spy(),
+			scServer: {
+				clients: {},
+			},
+		};
+		workerMock.on.reset();
+		workerMock.sendToMaster.reset();
+		slaveWampServer = new SlaveWAMPServer(workerMock);
+	});
+
 	describe('constructor', () => {
-		let fakeWorker;
-
-		beforeEach(() => {
-			fakeWorker = {
-				id: 0,
-				on: sinon.spy(),
-				scServer: {
-					clients: {},
-				},
-			};
-		});
-
 		it('create SlaveWAMPServer with worker field', () => {
-			const slaveWAMPServer = new SlaveWAMPServer(fakeWorker);
+			const slaveWAMPServer = new SlaveWAMPServer(workerMock);
 			expect(slaveWAMPServer).to.have.property('worker').to.be.a('object').and.to.have.property('id').equal(0);
 		});
 
 		it('create SlaveWAMPServer with RPCCalls field', () => {
-			const slaveWAMPServer = new SlaveWAMPServer(fakeWorker);
+			const slaveWAMPServer = new SlaveWAMPServer(workerMock);
 			expect(slaveWAMPServer).to.have.property('interProcessRPC').to.be.a('object').and.to.be.empty();
 		});
 
 		it('create SlaveWAMPServer with sockets field', () => {
-			const slaveWAMPServer = new SlaveWAMPServer(fakeWorker);
+			const slaveWAMPServer = new SlaveWAMPServer(workerMock);
 			expect(slaveWAMPServer).to.have.property('sockets').to.be.a('object').and.to.be.empty();
 		});
 
 		it('create SlaveWAMPServer with sockets field', () => {
-			const slaveWAMPServer = new SlaveWAMPServer(fakeWorker);
+			const slaveWAMPServer = new SlaveWAMPServer(workerMock);
 			expect(slaveWAMPServer).to.have.property('sockets').to.be.a('object').and.to.be.empty();
 		});
 
 		it('create SlaveWAMPServer and register event listener from master process', () => {
-			new SlaveWAMPServer(fakeWorker);
-			expect(fakeWorker.on.calledOnce).to.be.ok();
-			expect(fakeWorker.on.calledWith('masterMessage')).to.be.ok();
+			expect(workerMock.on.calledOnce).to.be.ok();
+			expect(workerMock.on.calledWith('masterMessage')).to.be.ok();
 		});
 	});
 
 	describe('normalizeRequest', () => {
 		let validRequest;
-		const normalizeRequest = SlaveWAMPServer.normalizeRequest;
+		let normalizeRequest;
 
 		beforeEach(() => {
+			normalizeRequest = SlaveWAMPServer.normalizeRequest;
 			validRequest = {
 				socketId: 'validSocketId',
 				procedure: 'validProcedure',
@@ -125,29 +136,16 @@ describe('SlaveWAMPServer', () => {
 	});
 
 	describe('processWAMPRequest', () => {
-		const workerMock = {
-			id: 'validWorkerId',
-			on: sinon.spy(),
-			sendToMaster: sinon.spy(),
-			scServer: {
-				clients: [],
-			},
-		};
-
-		const socketMock = {
-			id: 'validSocketId',
-			on: sinon.spy(),
-			send: sinon.spy(),
-		};
-
-		const slaveWampServer = new SlaveWAMPServer(workerMock);
-
+		let socketMock;
 		let validRequest;
 		let validSlaveToMasterRequest;
 
 		beforeEach(() => {
-			workerMock.on.reset();
-			workerMock.sendToMaster.reset();
+			socketMock = {
+				id: 'validSocketId',
+				on: sinon.spy(),
+				send: sinon.spy(),
+			};
 
 			socketMock.on.reset();
 			socketMock.send.reset();
@@ -161,7 +159,7 @@ describe('SlaveWAMPServer', () => {
 				procedure: 'procedureName',
 				type: '/MasterWAMPRequest',
 				socketId: 'validSocketId',
-				workerId: 'validWorkerId',
+				workerId: 0,
 			};
 		});
 
@@ -180,7 +178,7 @@ describe('SlaveWAMPServer', () => {
 				procedure: 'procedureName',
 				type: '/WAMPRequest',
 				socketId: 'validSocketId',
-				workerId: 'validWorkerId',
+				workerId: 0,
 			})).to.be.ok();
 
 			expect(workerMock.sendToMaster.called).not.to.be.ok();
@@ -195,7 +193,7 @@ describe('SlaveWAMPServer', () => {
 				procedure: 'procedureName',
 				type: '/WAMPRequest',
 				socketId: 'validSocketId',
-				workerId: 'validWorkerId',
+				workerId: 0,
 			})).to.be.ok();
 
 			expect(workerMock.sendToMaster.called).not.to.be.ok();
@@ -211,76 +209,305 @@ describe('SlaveWAMPServer', () => {
 				procedure: 'procedureName',
 				type: '/WAMPRequest',
 				socketId: 'validSocketId',
-				workerId: 'validWorkerId',
+				workerId: 0,
 			})).to.be.ok();
 
 			expect(workerMock.sendToMaster.called).not.to.be.ok();
 		});
 	});
 
-	describe('getCall', function () {
+	describe('sendToMaster', () => {
+		let validProcedure;
+		let validData;
+		let validSocketId;
+		let validSignature;
+		const actionCb = sinon.spy();
 
+		beforeEach(() => {
+			actionCb.reset();
+			validProcedure = 'validProcedure';
+			validData = { validKey: 'validValue' };
+			validSocketId = 'validSocketId';
+			validSignature = `${new Date().getTime()}_0`;
+		});
+
+		before(() => {
+			sinon.stub(Math, 'random').returns(0);
+		});
+
+		it('should pass correct InterProcessRPCRequestSchema compatible request to sendToMaster function', () => {
+			slaveWampServer.sendToMaster(validProcedure, validData, validSocketId, actionCb);
+			expect(workerMock.sendToMaster.calledOnce).to.be.ok();
+			expect(workerMock.sendToMaster.calledWith({
+				type: '/InterProcessRPCRequestSchema',
+				procedure: validProcedure,
+				data: validData,
+				socketId: validSocketId,
+				workerId: 0,
+				signature: validSignature,
+			})).to.be.ok();
+		});
+
+		it('should pass create a new entry in interProcessRPC map', () => {
+			slaveWampServer.sendToMaster(validProcedure, validData, validSocketId, actionCb);
+			expect(slaveWampServer.interProcessRPC).to.have.property(validSocketId);
+			expect(slaveWampServer.interProcessRPC[validSocketId]).to.have.property(validProcedure);
+			expect(slaveWampServer.interProcessRPC[validSocketId][validProcedure]).to.have.property(validSignature).to.be.a('function');
+		});
+	});
+
+	describe('onSocketDisconnect', () => {
+		let validSocketId;
+		let validProcedure;
+		let validSignature;
+
+		beforeEach(() => {
+			validSocketId = 'validSocketId';
+			validProcedure = 'validProcedure';
+			validSignature = 'validSignature';
+		});
+
+		it('should leave interProcessRPC in initial state when invoked without arguments', () => {
+			slaveWampServer.onSocketDisconnect();
+			expect(slaveWampServer.interProcessRPC).to.be.empty();
+		});
+
+		it('should leave interProcessRPC in initial state when entry does not exist', () => {
+			slaveWampServer.onSocketDisconnect(validSocketId);
+			expect(slaveWampServer.interProcessRPC).to.be.empty();
+		});
+
+		it('should remove existing entry from interProcessRPC', () => {
+			slaveWampServer.interProcessRPC = {
+				[validSocketId]: {
+					[validProcedure]: {
+						[validSignature]: () => {},
+					},
+				},
+			};
+			slaveWampServer.onSocketDisconnect(validSocketId);
+			expect(slaveWampServer.interProcessRPC).to.be.empty();
+		});
+	});
+
+	describe('saveCall', () => {
 		let validSocketId;
 		let validProcedure;
 		let validSignature;
 		let validRequest;
 		let validCb;
 
-		beforeEach(function () {
+		beforeEach(() => {
 			validSocketId = 'validSocketId';
 			validProcedure = 'validProcedure';
 			validSignature = 'validSignature';
 			validRequest = {
 				socketId: validSocketId,
 				procedure: validProcedure,
-				signature: validSignature
+				signature: validSignature,
 			};
 			validCb = () => {};
 		});
 
-		it('should return false when invoked without arguments', function () {
-			expect(slaveWampServer.getCall()).to.be.not.ok;
+		it('should throw an error when invoked without arguments', () => {
+			expect(() => {
+				slaveWampServer.saveCall();
+			}).to.throw('Cannot save a call for wrong InterProcessRPCRequest request');
+			expect(slaveWampServer.interProcessRPC).to.be.empty();
 		});
 
-		it('should return false when a call does not exist', function () {
-			expect(slaveWampServer.getCall(validRequest)).to.be.not.ok;
+		it('should throw an error when invoked without socket id', () => {
+			delete validRequest.socketId;
+			expect(() => {
+				slaveWampServer.saveCall(validRequest, validCb);
+			}).to.throw('Cannot save a call for wrong InterProcessRPCRequest request');
+			expect(slaveWampServer.interProcessRPC).to.be.empty();
 		});
 
-		describe('when call exists', function () {
+		it('should throw an error when invoked without procedure', () => {
+			delete validRequest.procedure;
+			expect(() => {
+				slaveWampServer.saveCall(validRequest, validCb);
+			}).to.throw('Cannot save a call for wrong InterProcessRPCRequest request');
+			expect(slaveWampServer.interProcessRPC).to.be.empty();
+		});
 
-			beforeEach(function () {
+		it('should throw an error when invoked without signature', () => {
+			delete validRequest.signature;
+			expect(() => {
+				slaveWampServer.saveCall(validRequest, validCb);
+			}).to.throw('Cannot save a call for wrong InterProcessRPCRequest request');
+			expect(slaveWampServer.interProcessRPC).to.be.empty();
+		});
+
+		it('should throw an error when invoked without callback', () => {
+			expect(() => {
+				slaveWampServer.saveCall(validRequest);
+			}).to.throw('Cannot save a call without callback');
+			expect(slaveWampServer.interProcessRPC).to.be.empty();
+		});
+
+		it('should create a new entry in interProcessRPC for valid request', () => {
+			slaveWampServer.saveCall(validRequest, validCb);
+			expect(slaveWampServer.interProcessRPC).to.have.property(validSocketId);
+			expect(slaveWampServer.interProcessRPC[validSocketId]).to.have.property(validProcedure);
+			expect(slaveWampServer.interProcessRPC[validSocketId][validProcedure]).to.have.property(validSignature).to.be.a('function');
+		});
+
+		it('should create multiple entries in interProcessRPC for multiple valid requests', () => {
+			slaveWampServer.saveCall(validRequest, validCb);
+			const validRequestB = validRequest;
+			validRequestB.socketId += 'B';
+			validRequestB.procedure += 'B';
+			validRequestB.signature += 'B';
+			slaveWampServer.saveCall(validRequestB, validCb);
+			expect(slaveWampServer.interProcessRPC).to.have.property(validSocketId);
+			expect(slaveWampServer.interProcessRPC[validSocketId]).to.have.property(validProcedure);
+			expect(slaveWampServer.interProcessRPC[validSocketId][validProcedure])
+				.to.have.property(validSignature).to.be.a('function');
+			expect(slaveWampServer.interProcessRPC).to.have.property(validRequestB.socketId);
+			expect(slaveWampServer.interProcessRPC[validRequestB.socketId])
+				.to.have.property(validRequestB.procedure);
+			expect(slaveWampServer.interProcessRPC[validRequestB.socketId][validRequestB.procedure])
+				.to.have.property(validRequestB.signature).to.be.a('function');
+		});
+	});
+
+	describe('deleteCall', () => {
+		let validSocketId;
+		let validProcedure;
+		let validSignature;
+		let validRequest;
+
+		beforeEach(() => {
+			validSocketId = 'validSocketId';
+			validProcedure = 'validProcedure';
+			validSignature = 'validSignature';
+			validRequest = {
+				socketId: validSocketId,
+				procedure: validProcedure,
+				signature: validSignature,
+			};
+		});
+
+		it('should throw an error when invoked without arguments', () => {
+			expect(() => {
+				slaveWampServer.deleteCall();
+			}).to.throw('Cannot delete a call for wrong InterProcessRPCRequest request');
+			expect(slaveWampServer.interProcessRPC).to.be.empty();
+		});
+
+		it('should throw an error when invoked without socket id', () => {
+			delete validRequest.socketId;
+			expect(() => {
+				slaveWampServer.deleteCall(validRequest);
+			}).to.throw('Cannot delete a call for wrong InterProcessRPCRequest request');
+			expect(slaveWampServer.interProcessRPC).to.be.empty();
+		});
+
+		it('should throw an error when invoked without procedure', () => {
+			delete validRequest.procedure;
+			expect(() => {
+				slaveWampServer.deleteCall(validRequest);
+			}).to.throw('Cannot delete a call for wrong InterProcessRPCRequest request');
+			expect(slaveWampServer.interProcessRPC).to.be.empty();
+		});
+
+		it('should throw an error when invoked without signature', () => {
+			delete validRequest.signature;
+			expect(() => {
+				slaveWampServer.deleteCall(validRequest);
+			}).to.throw('Cannot delete a call for wrong InterProcessRPCRequest request');
+			expect(slaveWampServer.interProcessRPC).to.be.empty();
+		});
+
+		it('should throw an error when entry does not exist', () => {
+			expect(() => {
+				slaveWampServer.deleteCall(validRequest);
+			}).to.throw('There is no internal requests registered for socket: validSocketId, procedure: validProcedure with signature validSignature');
+		});
+
+		describe('when call exists', () => {
+			beforeEach(() => {
 				slaveWampServer.interProcessRPC = {
 					[validSocketId]: {
 						[validProcedure]: {
-							[validSignature]: () => {}
-						}
-					}
+							[validSignature]: () => {},
+						},
+					},
 				};
 			});
 
-			it('should return false when invoked without socket id', function () {
-				delete validRequest.socketId;
-				expect(slaveWampServer.getCall()).to.be.not.ok;
-			});
-
-			it('should return false when invoked without procedure', function () {
-				delete validRequest.procedure;
-				expect(slaveWampServer.getCall()).to.be.not.ok;
-			});
-
-			it('should return false when invoked without signature', function () {
-				delete validRequest.signature;
-				expect(slaveWampServer.getCall()).to.be.not.ok;
-			});
-
-			it('should return false when invoked without signature', function () {
-				delete validRequest.signature;
-				expect(slaveWampServer.getCall()).to.be.not.ok;
-			});
-
-			it('should return true when invoked with valid request', function () {
-				expect(slaveWampServer.getCall(validRequest)).to.be.ok;
+			it('should delete existing signature call for procedure in interProcessRPC', () => {
+				slaveWampServer.deleteCall(validRequest);
+				expect(slaveWampServer.interProcessRPC[validSocketId][validProcedure]).to.be.empty();
 			});
 		});
 	});
+
+	describe('getCall', () => {
+		let validSocketId;
+		let validProcedure;
+		let validSignature;
+		let validRequest;
+
+		beforeEach(() => {
+			validSocketId = 'validSocketId';
+			validProcedure = 'validProcedure';
+			validSignature = 'validSignature';
+			validRequest = {
+				socketId: validSocketId,
+				procedure: validProcedure,
+				signature: validSignature,
+			};
+		});
+
+		it('should return false when invoked without arguments', () => {
+			expect(slaveWampServer.getCall()).to.be.not.ok();
+		});
+
+		it('should return false when a call does not exist', () => {
+			expect(slaveWampServer.getCall(validRequest)).to.be.not.ok();
+		});
+
+		describe('when call exists', () => {
+			beforeEach(() => {
+				slaveWampServer.interProcessRPC = {
+					[validSocketId]: {
+						[validProcedure]: {
+							[validSignature]: () => {},
+						},
+					},
+				};
+			});
+
+			it('should return false when invoked without socket id', () => {
+				delete validRequest.socketId;
+				expect(slaveWampServer.getCall()).to.be.not.ok();
+			});
+
+			it('should return false when invoked without procedure', () => {
+				delete validRequest.procedure;
+				expect(slaveWampServer.getCall()).to.be.not.ok();
+			});
+
+			it('should return false when invoked without signature', () => {
+				delete validRequest.signature;
+				expect(slaveWampServer.getCall()).to.be.not.ok();
+			});
+
+			it('should return false when invoked without signature', () => {
+				delete validRequest.signature;
+				expect(slaveWampServer.getCall()).to.be.not.ok();
+			});
+
+			it('should return true when invoked with valid request', () => {
+				expect(slaveWampServer.getCall(validRequest)).to.be.ok();
+			});
+		});
+	});
+});
+
+after(() => {
+	clock.restore();
 });

--- a/SlaveWAMPServer.spec.js
+++ b/SlaveWAMPServer.spec.js
@@ -217,4 +217,70 @@ describe('SlaveWAMPServer', () => {
 			expect(workerMock.sendToMaster.called).not.to.be.ok();
 		});
 	});
+
+	describe('getCall', function () {
+
+		let validSocketId;
+		let validProcedure;
+		let validSignature;
+		let validRequest;
+		let validCb;
+
+		beforeEach(function () {
+			validSocketId = 'validSocketId';
+			validProcedure = 'validProcedure';
+			validSignature = 'validSignature';
+			validRequest = {
+				socketId: validSocketId,
+				procedure: validProcedure,
+				signature: validSignature
+			};
+			validCb = () => {};
+		});
+
+		it('should return false when invoked without arguments', function () {
+			expect(slaveWampServer.getCall()).to.be.not.ok;
+		});
+
+		it('should return false when a call does not exist', function () {
+			expect(slaveWampServer.getCall(validRequest)).to.be.not.ok;
+		});
+
+		describe('when call exists', function () {
+
+			beforeEach(function () {
+				slaveWampServer.interProcessRPC = {
+					[validSocketId]: {
+						[validProcedure]: {
+							[validSignature]: () => {}
+						}
+					}
+				};
+			});
+
+			it('should return false when invoked without socket id', function () {
+				delete validRequest.socketId;
+				expect(slaveWampServer.getCall()).to.be.not.ok;
+			});
+
+			it('should return false when invoked without procedure', function () {
+				delete validRequest.procedure;
+				expect(slaveWampServer.getCall()).to.be.not.ok;
+			});
+
+			it('should return false when invoked without signature', function () {
+				delete validRequest.signature;
+				expect(slaveWampServer.getCall()).to.be.not.ok;
+			});
+
+			it('should return false when invoked without signature', function () {
+				delete validRequest.signature;
+				expect(slaveWampServer.getCall()).to.be.not.ok;
+			});
+
+			it('should return true when invoked with valid request', function () {
+				expect(slaveWampServer.getCall(validRequest)).to.be.ok;
+			});
+		});
+	});
 });

--- a/SlaveWAMPServer.spec.js
+++ b/SlaveWAMPServer.spec.js
@@ -173,7 +173,7 @@ describe('SlaveWAMPServer', () => {
 		it('should pass request forward to master if procedure is not registered in SlaveWAMPServer', () => {
 			slaveWAMPServer.processWAMPRequest(validWAMPRequest, socketMock);
 			expect(workerMock.sendToMaster.calledOnce).to.be.true();
-			expect(workerMock.sendToMaster.calledWith(validSlaveToMasterRequest)).to.be.true();
+			expect(workerMock.sendToMaster.calledWithExactly(validSlaveToMasterRequest)).to.be.true();
 		});
 
 		it('should invoke procedure on SlaveWAMPServer if registered before', () => {
@@ -235,7 +235,7 @@ describe('SlaveWAMPServer', () => {
 		it('should pass correct InterProcessRPCRequestSchema compatible request to sendToMaster function', () => {
 			slaveWAMPServer.sendToMaster(validProcedure, validData, validSocketId, validCb);
 			expect(workerMock.sendToMaster.calledOnce).to.be.true();
-			expect(workerMock.sendToMaster.calledWith({
+			expect(workerMock.sendToMaster.calledWithExactly({
 				type: '/InterProcessRPCRequestSchema',
 				procedure: validProcedure,
 				data: validData,

--- a/WAMPClient.js
+++ b/WAMPClient.js
@@ -3,7 +3,7 @@ const schemas = require('./schemas');
 
 class WAMPClient {
 	/**
-	 * @return {number}
+	 * @returns {number}
 	 */
 	static get MAX_CALLS_ALLOWED() {
 		return 100;

--- a/WAMPClient.js
+++ b/WAMPClient.js
@@ -10,7 +10,7 @@ class WAMPClient {
 	}
 
 	/**
-	 * @param {object} procedureCalls
+	 * @param {Object} procedureCalls
 	 * @returns {*}
 	 */
 	static generateSignature(procedureCalls) {
@@ -32,8 +32,8 @@ class WAMPClient {
 	}
 
 	/**
-	 * @param {object} socket - SocketCluster.Socket
-	 * @returns {object} wampSocket
+	 * @param {Object} socket - SocketCluster.Socket
+	 * @returns {Object} wampSocket
 	 */
 	upgradeToWAMP(socket) {
 		if (socket.wampSend && socket.listeners('raw').length) {

--- a/WAMPClient.spec.js
+++ b/WAMPClient.spec.js
@@ -166,7 +166,7 @@ describe('WAMPClient', () => {
 						},
 					};
 
-					expect(v.validate(sampleWampServerResponse, WAMPResponseSchema).valid).to.be.ok();
+					expect(v.validate(sampleWampServerResponse, WAMPResponseSchema).valid).to.be.true();
 
 					wampSocket.wampSend(procedure).then((data) => {
 						expect(data).equal(sampleWampServerResponse.data);

--- a/WAMPClient.spec.js
+++ b/WAMPClient.spec.js
@@ -14,6 +14,10 @@ before(() => {
 	clock = sinon.useFakeTimers(new Date(2020, 1, 1).getTime());
 });
 
+after(() => {
+	clock.restore();
+});
+
 describe('WAMPClient', () => {
 	let fakeSocket;
 
@@ -44,12 +48,6 @@ describe('WAMPClient', () => {
 			const someArgument = {
 				propA: 'valueA',
 			};
-
-			before(() => {
-				if (Math.random.restore) {
-					Math.random.restore();
-				}
-			});
 
 			beforeEach(() => {
 				wampClient = new WAMPClient(fakeSocket);
@@ -255,8 +253,4 @@ describe('WAMPClient', () => {
 			});
 		});
 	});
-});
-
-after(() => {
-	clock.restore();
 });

--- a/WAMPClient.spec.js
+++ b/WAMPClient.spec.js
@@ -144,12 +144,14 @@ describe('WAMPClient', () => {
 			});
 
 			describe('resolving responses', () => {
+				let mathRandomStub;
+
 				before(() => {
-					Math.random = sinon.stub(Math, 'random').returns(0);
+					mathRandomStub = sinon.stub(Math, 'random').returns(0);
 				});
 
 				after(() => {
-					Math.random.restore();
+					mathRandomStub.restore();
 				});
 
 

--- a/WAMPClient.spec.js
+++ b/WAMPClient.spec.js
@@ -45,6 +45,12 @@ describe('WAMPClient', () => {
 				propA: 'valueA',
 			};
 
+			before(() => {
+				if (Math.random.restore) {
+					Math.random.restore();
+				}
+			});
+
 			beforeEach(() => {
 				wampClient = new WAMPClient(fakeSocket);
 				wampSocket = {
@@ -241,6 +247,10 @@ describe('WAMPClient', () => {
 						expect(err.toString()).equal(`Error: Unable to find resolving function for procedure ${procedure} with signature ${sampleWampServerResponse.signature}`);
 						done();
 					}
+				});
+
+				after(() => {
+					Math.random.restore();
 				});
 			});
 		});

--- a/WAMPClient.spec.js
+++ b/WAMPClient.spec.js
@@ -145,7 +145,7 @@ describe('WAMPClient', () => {
 
 			describe('resolving responses', () => {
 				before(() => {
-					sinon.stub(Math, 'random').returns(0);
+					Math.random = sinon.stub(Math, 'random').returns(0);
 				});
 
 				after(() => {

--- a/WAMPClient.spec.js
+++ b/WAMPClient.spec.js
@@ -112,7 +112,7 @@ describe('WAMPClient', () => {
 				const procedure = 'procedureA';
 
 				wampSocket.wampSend(procedure);
-				expect(wampSocket.send.calledOnce).to.be.ok();
+				expect(wampSocket.send.calledOnce).to.be.true();
 			});
 
 			it('should invoke socket.emit function with passed arguments', () => {
@@ -130,7 +130,7 @@ describe('WAMPClient', () => {
 				const procedure = 'procedureA';
 
 				wampSocket.wampSend(procedure);
-				expect(wampSocket.on.calledOnce).to.be.ok();
+				expect(wampSocket.on.calledOnce).to.be.true();
 			});
 
 			it('should invoke socket.on function with passed arguments', () => {
@@ -146,6 +146,10 @@ describe('WAMPClient', () => {
 			describe('resolving responses', () => {
 				before(() => {
 					sinon.stub(Math, 'random').returns(0);
+				});
+
+				after(() => {
+					Math.random.restore();
 				});
 
 
@@ -245,10 +249,6 @@ describe('WAMPClient', () => {
 						expect(err.toString()).equal(`Error: Unable to find resolving function for procedure ${procedure} with signature ${sampleWampServerResponse.signature}`);
 						done();
 					}
-				});
-
-				after(() => {
-					Math.random.restore();
 				});
 			});
 		});

--- a/WAMPServer.js
+++ b/WAMPServer.js
@@ -58,6 +58,7 @@ class WAMPServer {
 	/**
 	 * @param {WAMPRequestSchema} request
 	 * @param {SocketCluster.Socket} socket
+	 * @returns {undefined}
 	 */
 	processWAMPRequest(request, socket) {
 		if (this.endpoints.rpc[request.procedure] &&
@@ -79,6 +80,7 @@ class WAMPServer {
 	 * @param {WAMPRequestSchema} request
 	 * @param {*} error
 	 * @param {*} data
+	 * @returns {undefined}
 	 */
 	/* eslint class-methods-use-this: 0 */
 	reply(socket, request, error, data) {
@@ -93,6 +95,7 @@ class WAMPServer {
 
 	/**
 	 * @param {Map<RPCEndpoint>} endpoints
+	 * @returns {undefined}
 	 */
 	registerRPCEndpoints(endpoints) {
 		this.endpoints.rpc = Object.assign(this.endpoints.rpc, endpoints);
@@ -100,6 +103,7 @@ class WAMPServer {
 
 	/**
 	 * @param {Map<RPCEndpoint>} endpoints
+	 * @returns {undefined}
 	 */
 	registerEventEndpoints(endpoints) {
 		this.endpoints.event = Object.assign(this.endpoints.event, endpoints);
@@ -107,6 +111,7 @@ class WAMPServer {
 
 	/**
 	 * @param {Map<RPCEndpoint>} endpoints
+	 * @returns {undefined}
 	 */
 	reassignRPCEndpoints(endpoints) {
 		this.endpoints.rpc = endpoints;
@@ -114,6 +119,7 @@ class WAMPServer {
 
 	/**
 	 * @param {Map<RPCEndpoint>} endpoints
+	 * @returns {undefined}
 	 */
 	reassignEventEndpoints(endpoints) {
 		this.endpoints.event = endpoints;

--- a/WAMPServer.js
+++ b/WAMPServer.js
@@ -37,7 +37,7 @@ class WAMPServer {
 				return;
 			}
 			if (schemas.isValid(parsedRequest, schemas.WAMPRequestSchema)) {
-				this.processWAMPRequest(request, socket);
+				this.processWAMPRequest(parsedRequest, socket);
 			}
 		});
 

--- a/WAMPServer.js
+++ b/WAMPServer.js
@@ -9,10 +9,10 @@ class WAMPServer {
 	}
 
 	/**
-	 * @param {object} request
+	 * @param {Object} request
 	 * @param {Error} error
 	 * @param {*} data
-	 * @returns {object}
+	 * @returns {Object}
 	 */
 	static createResponsePayload(request, error, data) {
 		return Object.assign({}, request, {
@@ -24,8 +24,8 @@ class WAMPServer {
 	}
 
 	/**
-	 * @param {object} socket - SocketCluster.Socket
-	 * @returns {object} wampSocket
+	 * @param {Object} socket - SocketCluster.Socket
+	 * @returns {Object} wampSocket
 	 */
 	upgradeToWAMP(socket) {
 		// register RPC endpoints

--- a/WAMPServer.spec.js
+++ b/WAMPServer.spec.js
@@ -19,7 +19,7 @@ describe('WAMPServer', () => {
 			};
 			socket = new WAMPServer().upgradeToWAMP(socket);
 			expect(socket.on.calledOnce).to.be.true();
-			expect(socket.on.calledWith('raw')).to.be.ok();
+			expect(socket.on.calledWith('raw')).to.be.true();
 		});
 	});
 
@@ -109,7 +109,7 @@ describe('WAMPServer', () => {
 			wampServer.registerRPCEndpoints(endpoint);
 			wampServer.processWAMPRequest({ procedure: 'procedureA', data: 'valueA' }, socket);
 			expect(endpoint.procedureA.calledOnce).to.be.true();
-			expect(endpoint.procedureA.calledWith('valueA')).to.be.ok();
+			expect(endpoint.procedureA.calledWith('valueA')).to.be.true();
 		});
 	});
 });

--- a/WAMPServer.spec.js
+++ b/WAMPServer.spec.js
@@ -112,4 +112,6 @@ describe('WAMPServer', () => {
 			expect(endpoint.procedureA.calledWith('valueA')).to.be.ok();
 		});
 	});
+
+
 });

--- a/WAMPServer.spec.js
+++ b/WAMPServer.spec.js
@@ -112,6 +112,4 @@ describe('WAMPServer', () => {
 			expect(endpoint.procedureA.calledWith('valueA')).to.be.ok();
 		});
 	});
-
-
 });

--- a/WAMPServer.spec.js
+++ b/WAMPServer.spec.js
@@ -18,7 +18,7 @@ describe('WAMPServer', () => {
 				on: sinon.spy(),
 			};
 			socket = new WAMPServer().upgradeToWAMP(socket);
-			expect(socket.on.calledOnce).to.be.ok();
+			expect(socket.on.calledOnce).to.be.true();
 			expect(socket.on.calledWith('raw')).to.be.ok();
 		});
 	});
@@ -108,7 +108,7 @@ describe('WAMPServer', () => {
 			wampServer.upgradeToWAMP(socket);
 			wampServer.registerRPCEndpoints(endpoint);
 			wampServer.processWAMPRequest({ procedure: 'procedureA', data: 'valueA' }, socket);
-			expect(endpoint.procedureA.calledOnce).to.be.ok();
+			expect(endpoint.procedureA.calledOnce).to.be.true();
 			expect(endpoint.procedureA.calledWith('valueA')).to.be.ok();
 		});
 	});

--- a/WAMPServer.spec.js
+++ b/WAMPServer.spec.js
@@ -7,8 +7,8 @@ describe('WAMPServer', () => {
 	describe('constructor', () => {
 		it('create wampServer with endpoints field', () => {
 			const wampServer = new WAMPServer();
-			expect(wampServer).to.have.deep.property('endpoints.rpc').to.be.a('object').and.to.be.empty();
-			expect(wampServer).to.have.deep.property('endpoints.event').to.be.a('object').and.to.be.empty();
+			expect(wampServer).to.have.nested.property('endpoints.rpc').to.be.a('object').and.to.be.empty();
+			expect(wampServer).to.have.nested.property('endpoints.event').to.be.a('object').and.to.be.empty();
 		});
 	});
 

--- a/example/client.js
+++ b/example/client.js
@@ -34,7 +34,7 @@ Client.prototype.callRPCInInterval = () => {
 		console.info('invoked multiplyByTwo RPC function with parameter: ', randNumber);
 		this.socket.wampSend('multiplyByTwo', randNumber)
 			.then(result => console.info(`RPC result: ${randNumber} * 2 = ${result}`))
-			.catch(() => console.error('RPC multiply by two error'));
+			.catch(err => console.error('RPC multiply by two error', err));
 	}, 1000);
 
 	this.socket.on('disconnect', () => {

--- a/example/client.js
+++ b/example/client.js
@@ -35,6 +35,8 @@ Client.prototype.callRPCInInterval = () => {
 		this.socket.wampSend('multiplyByTwo', randNumber)
 			.then(result => console.info(`RPC result: ${randNumber} * 2 = ${result}`))
 			.catch(err => console.error('RPC multiply by two error', err));
+
+		this.socket.wampSend('multiplyByThree', randNumber);
 	}, 1000);
 
 	this.socket.on('disconnect', () => {

--- a/example/serverWorker.js
+++ b/example/serverWorker.js
@@ -2,6 +2,10 @@ const rpcEndpoints = {
 	multiplyByTwo: (num, cb) => cb(null, num * 2),
 };
 
+const eventEndpoints = {
+	multiplyByThree: num => console.info(`On server event action 'multiplyByThree': ${num} * 3 = ${num * 3}`),
+};
+
 const WAMPServer = require('../WAMPServer');
 
 module.exports.run = (worker) => {
@@ -13,5 +17,6 @@ module.exports.run = (worker) => {
 		wampServer.upgradeToWAMP(socket);
 
 		wampServer.registerRPCEndpoints(rpcEndpoints);
+		wampServer.registerEventEndpoints(eventEndpoints);
 	});
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-core": "=6.24.0",
     "babel-loader": "=6.4.1",
     "babel-preset-env": "=1.2.2",
-    "chai": "=3.5.0",
+    "chai": "=4.1.1",
     "dirty-chai": "=2.0.1",
     "eslint": "=4.3.0",
     "eslint-config-airbnb-base": "=11.3.1",


### PR DESCRIPTION
Adds missing SlaveWAMPServer tests, jsdocs - Closes #2. This PR fixes also the RPC example and adds working example of calling an event procedure, which seems to close #11.