### PR TITLE
Usage of lodash "get" and "set" functions leads to memory leaks - Closes #24

### DIFF
--- a/SlaveWAMPServer.js
+++ b/SlaveWAMPServer.js
@@ -150,7 +150,9 @@ class SlaveWAMPServer extends WAMPServer {
 		if (!this.interProcessRPC[request.socketId][request.procedure]) {
 			this.interProcessRPC[request.socketId][request.procedure] = {};
 		}
-		this.interProcessRPC[request.socketId][request.procedure][request.signature] = { callback, requestTimeout };
+		this.interProcessRPC[request.socketId][request.procedure][request.signature] = {
+			callback, requestTimeout,
+		};
 	}
 
 	/**

--- a/SlaveWAMPServer.js
+++ b/SlaveWAMPServer.js
@@ -122,7 +122,6 @@ class SlaveWAMPServer extends WAMPServer {
 	/**
 	 * @param {InterProcessRPCRequestSchema} request
 	 * @param {Function} callback
-	 * @returns {Object}
 	 */
 	saveCall(request, callback) {
 		if (!request) {

--- a/SlaveWAMPServer.js
+++ b/SlaveWAMPServer.js
@@ -1,6 +1,5 @@
 const Validator = require('jsonschema').Validator;
-const setWith = require('lodash.setwith');
-const get = require('lodash.get');
+const get = require('./utils').get;
 const WAMPServer = require('./WAMPServer');
 const WAMPClient = require('./WAMPClient');
 
@@ -145,7 +144,14 @@ class SlaveWAMPServer extends WAMPServer {
 			callback('RPC response timeout exceeded');
 			this.deleteCall(request);
 		}, this.internalRequestsTimeoutMs);
-		return setWith(this.interProcessRPC, `${request.socketId}.${request.procedure}.${request.signature}`, { callback, requestTimeout }, Object);
+
+		if (!this.interProcessRPC[request.socketId]) {
+			this.interProcessRPC[request.socketId] = {};
+		}
+		if (!this.interProcessRPC[request.socketId][request.procedure]) {
+			this.interProcessRPC[request.socketId][request.procedure] = {};
+		}
+		this.interProcessRPC[request.socketId][request.procedure][request.signature] = { callback, requestTimeout };
 	}
 
 	/**

--- a/WAMPClient.js
+++ b/WAMPClient.js
@@ -50,12 +50,17 @@ class WAMPClient {
 			return socket;
 		}
 		const wampSocket = socket;
-		wampSocket.on('raw', (result) => {
-			// Cast JSON string to an object if possible.
-			try {
-				result = JSON.parse(result);
-			} catch (err) {}
 
+		const enforceObject = (any) => {
+			try {
+				return JSON.parse(any);
+			} catch (ex) {
+				return any;
+			}
+		};
+
+		wampSocket.on('raw', (rawResult) => {
+			const result = enforceObject(rawResult);
 			if (schemas.isValid(result, schemas.WAMPResponseSchema)) {
 				const resolvers = get(this.callsResolvers, `${result.procedure}.${result.signature}`);
 				if (resolvers) {

--- a/WAMPClient.js
+++ b/WAMPClient.js
@@ -1,4 +1,4 @@
-const get = require('lodash.get');
+const get = require('./utils').get;
 const schemas = require('./schemas');
 
 class WAMPClient {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
   "license": "GPLv3",
   "dependencies": {
     "jsonschema": "=1.1.1",
-    "lodash.filter": "=4.6.0",
-    "lodash.get": "=4.4.2",
-    "lodash.setwith": "=4.3.2"
+    "lodash.filter": "=4.6.0"
   },
   "devDependencies": {
     "babel-core": "=6.24.0",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   "author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
   "license": "GPLv3",
   "dependencies": {
-    "jsonschema": "=1.1.1",
-    "lodash.filter": "=4.6.0"
+    "jsonschema": "=1.1.1"
   },
   "devDependencies": {
     "babel-core": "=6.24.0",

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,18 @@
+const utils = {
+	get: (obj, deepKeyString, defaultValue = undefined) => {
+		if (typeof deepKeyString !== 'string') {
+			return defaultValue;
+		}
+		const deepKeyArray = deepKeyString.split('.');
+		let currentResult = obj;
+		for (const key of deepKeyArray) {
+			currentResult = currentResult[key];
+			if (currentResult === undefined) {
+				return defaultValue;
+			}
+		}
+		return currentResult;
+	}
+};
+
+module.exports = utils;

--- a/utils.js
+++ b/utils.js
@@ -5,14 +5,15 @@ const utils = {
 		}
 		const deepKeyArray = deepKeyString.split('.');
 		let currentResult = obj;
-		for (const key of deepKeyArray) {
-			currentResult = currentResult[key];
+
+		for (let i = 0; i < deepKeyArray.length; i += 1) {
+			currentResult = currentResult[deepKeyArray[i]];
 			if (currentResult === undefined) {
 				return defaultValue;
 			}
 		}
 		return currentResult;
-	}
+	},
 };
 
 module.exports = utils;

--- a/utils.spec.js
+++ b/utils.spec.js
@@ -4,9 +4,7 @@ const { expect } = require('./testSetup.spec');
 const utils = require('./utils');
 
 describe('utils', () => {
-
 	describe('get', () => {
-
 		let validPath;
 		let validObject;
 		let validDefaultValue;
@@ -19,14 +17,12 @@ describe('utils', () => {
 			validDefaultValue = undefined;
 		});
 
-		beforeEach(function () {
+		beforeEach(() => {
 			getResult = utils.get(validObject, validPath, validDefaultValue);
 		});
 
 		describe('when path is not a string', () => {
-
 			describe('when path is an object', () => {
-
 				before(() => {
 					validPath = {};
 				});
@@ -37,7 +33,6 @@ describe('utils', () => {
 			});
 
 			describe('when path is an array', () => {
-
 				before(() => {
 					validPath = [];
 				});
@@ -48,7 +43,6 @@ describe('utils', () => {
 			});
 
 			describe('when path is a number', () => {
-
 				before(() => {
 					const validNumber = 1;
 					validPath = validNumber;
@@ -60,7 +54,6 @@ describe('utils', () => {
 			});
 
 			describe('when path is null', () => {
-
 				before(() => {
 					validPath = null;
 				});
@@ -71,7 +64,6 @@ describe('utils', () => {
 			});
 
 			describe('when path is undefined', () => {
-
 				before(() => {
 					validPath = undefined;
 				});
@@ -83,9 +75,7 @@ describe('utils', () => {
 		});
 
 		describe('when path is a string', () => {
-
-			describe('and is empty', function () {
-
+			describe('and is empty', () => {
 				before(() => {
 					validPath = '';
 				});
@@ -95,22 +85,20 @@ describe('utils', () => {
 				});
 			});
 
-			describe('when accessing nested object', function () {
-
+			describe('when accessing nested object', () => {
 				before(() => {
 					validObject = {
 						a: {
 							b: {
 								c: {
-									d: 'abcd'
-								}
-							}
-						}
+									d: 'abcd',
+								},
+							},
+						},
 					};
 				});
 
 				describe('when accessing property does not exist', () => {
-
 					before(() => {
 						validPath = 'A.B.C.D';
 					});
@@ -119,8 +107,7 @@ describe('utils', () => {
 						expect(getResult).to.be.undefined();
 					});
 
-					describe('when defaultValue = false', function () {
-
+					describe('when defaultValue = false', () => {
 						before(() => {
 							validDefaultValue = false;
 						});
@@ -132,9 +119,7 @@ describe('utils', () => {
 				});
 
 				describe('when accessing property exists', () => {
-
-					describe('and points to the middle-path value', function () {
-
+					describe('and points to the middle-path value', () => {
 						before(() => {
 							validPath = 'a.b';
 						});
@@ -142,20 +127,19 @@ describe('utils', () => {
 						it('should return {c: {d: "abcd"}}}', () => {
 							expect(getResult).to.eql({
 								c: {
-									d: 'abcd'
-								}
+									d: 'abcd',
+								},
 							});
 						});
 					});
 
-					describe('and points to the final value', function () {
-
+					describe('and points to the final value', () => {
 						before(() => {
 							validPath = 'a.b.c.d';
 						});
 
 						it('should return "abcd"', () => {
-							expect(getResult).to.equal('abcd')
+							expect(getResult).to.equal('abcd');
 						});
 					});
 				});

--- a/utils.spec.js
+++ b/utils.spec.js
@@ -1,0 +1,165 @@
+/* eslint-env node, mocha */
+const { expect } = require('./testSetup.spec');
+
+const utils = require('./utils');
+
+describe('utils', () => {
+
+	describe('get', () => {
+
+		let validPath;
+		let validObject;
+		let validDefaultValue;
+
+		let getResult;
+
+		before(() => {
+			validPath = '';
+			validObject = {};
+			validDefaultValue = undefined;
+		});
+
+		beforeEach(function () {
+			getResult = utils.get(validObject, validPath, validDefaultValue);
+		});
+
+		describe('when path is not a string', () => {
+
+			describe('when path is an object', () => {
+
+				before(() => {
+					validPath = {};
+				});
+
+				it('should return undefined', () => {
+					expect(getResult).to.be.undefined();
+				});
+			});
+
+			describe('when path is an array', () => {
+
+				before(() => {
+					validPath = [];
+				});
+
+				it('should return undefined', () => {
+					expect(getResult).to.be.undefined();
+				});
+			});
+
+			describe('when path is a number', () => {
+
+				before(() => {
+					const validNumber = 1;
+					validPath = validNumber;
+				});
+
+				it('should return undefined', () => {
+					expect(getResult).to.be.undefined();
+				});
+			});
+
+			describe('when path is null', () => {
+
+				before(() => {
+					validPath = null;
+				});
+
+				it('should return undefined', () => {
+					expect(getResult).to.be.undefined();
+				});
+			});
+
+			describe('when path is undefined', () => {
+
+				before(() => {
+					validPath = undefined;
+				});
+
+				it('should return undefined', () => {
+					expect(getResult).to.be.undefined();
+				});
+			});
+		});
+
+		describe('when path is a string', () => {
+
+			describe('and is empty', function () {
+
+				before(() => {
+					validPath = '';
+				});
+
+				it('should return undefined', () => {
+					expect(getResult).to.be.undefined();
+				});
+			});
+
+			describe('when accessing nested object', function () {
+
+				before(() => {
+					validObject = {
+						a: {
+							b: {
+								c: {
+									d: 'abcd'
+								}
+							}
+						}
+					};
+				});
+
+				describe('when accessing property does not exist', () => {
+
+					before(() => {
+						validPath = 'A.B.C.D';
+					});
+
+					it('should return undefined', () => {
+						expect(getResult).to.be.undefined();
+					});
+
+					describe('when defaultValue = false', function () {
+
+						before(() => {
+							validDefaultValue = false;
+						});
+
+						it('should return undefined', () => {
+							expect(getResult).to.be.false();
+						});
+					});
+				});
+
+				describe('when accessing property exists', () => {
+
+					describe('and points to the middle-path value', function () {
+
+						before(() => {
+							validPath = 'a.b';
+						});
+
+						it('should return {c: {d: "abcd"}}}', () => {
+							expect(getResult).to.eql({
+								c: {
+									d: 'abcd'
+								}
+							});
+						});
+					});
+
+					describe('and points to the final value', function () {
+
+						before(() => {
+							validPath = 'a.b.c.d';
+						});
+
+						it('should return "abcd"', () => {
+							expect(getResult).to.equal('abcd')
+						});
+					});
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
Remove usages of lodash.set and lodash.get to avoid caching RPC calls. Use native equivalents instead. 

Closes #24.