### PR TITLE
Do not throw error/crash the worker process if an RPC response socket cannot be found - Closes #31

### DIFF
--- a/SlaveWAMPServer.js
+++ b/SlaveWAMPServer.js
@@ -34,7 +34,7 @@ class SlaveWAMPServer extends WAMPServer {
 					response.type = schemas.RPCRequestSchema.id;
 					this.reply(socket, response, response.error, response.data);
 				} else {
-					throw new Error('Socket that requested RPC call not found anymore');
+					console.log('Socket that requested RPC call not found anymore');
 				}
 			} else if (schemas.isValid(response, schemas.InterProcessRPCResponseSchema)) {
 				const callback = this.getCall(response);


### PR DESCRIPTION
If the peer disconnected from the node before the processing of the RPC had completed, then the node would sometimes try to send back the response to the peer using the disconnected socket (which no longer exists) and this would cause an error to be thrown.

This is actually a normal scenario and so we shouldn't throw a fatal error (which would crash the process).

Closes: https://github.com/LiskHQ/wamp-socket-cluster/issues/31